### PR TITLE
#2: Use School Name, Not Mascot Name

### DIFF
--- a/src/assemblies/data/ncaab/league/NcaabMensTop25Entry/NcaabMensTop25Entry.tsx
+++ b/src/assemblies/data/ncaab/league/NcaabMensTop25Entry/NcaabMensTop25Entry.tsx
@@ -81,7 +81,7 @@ export const NcaabMensTop25Entry : FC<NcaabMensTop25EntryProps>  = (props) =>{
                     }}>
                         <img height={24} width={24} src={_team.TeamLogoUrl}/>
                         &emsp;
-                        {_team.Name}
+                        {_team.School}
                     </div>
                 </div>
                 <div 

--- a/src/assemblies/data/ncaab/league/TopTeamEntry/TopTeamEntry.tsx
+++ b/src/assemblies/data/ncaab/league/TopTeamEntry/TopTeamEntry.tsx
@@ -56,7 +56,7 @@ export const TopTeamEntry : FC<TopTeamEntryProps>  = (props) =>{
             style={{...!props.overrideStyle ? TOP_TEAM_ENTRY_INNER_STYLE : {}, ...props.style}}>
                 <img height={24} width={24} src={_team.TeamLogoUrl}/>
                 &emsp;
-                {_team.Name}
+                {_team.School}
                 <span style={{
                     opacity : .5
                 }} className='text-sm'>{props.stat}</span>

--- a/src/assemblies/data/ncaab/matchup/OffenseDefensePointRadar/OffenseDefensePointRadar.tsx
+++ b/src/assemblies/data/ncaab/matchup/OffenseDefensePointRadar/OffenseDefensePointRadar.tsx
@@ -115,7 +115,7 @@ export const OffenseDefensePointRadar : FC<OffenseDefensePointRadarProps>  = (pr
                         </div>
                         &emsp;
                         <div>
-                        {_offensiveTeam.Name} {props.reverse ? "(DEF)" : "(OFF)"}
+                        {_offensiveTeam.School} {props.reverse ? "(DEF)" : "(OFF)"}
                         </div>
                     </div>
                     <div style={{
@@ -133,7 +133,7 @@ export const OffenseDefensePointRadar : FC<OffenseDefensePointRadarProps>  = (pr
                         </div>
                         &emsp;
                         <div>
-                        {_defensiveTeam.Name} {props.reverse ? "(OFF)" : "(DEF)"}
+                        {_defensiveTeam.School} {props.reverse ? "(OFF)" : "(DEF)"}
                         </div>
                     </div>
                 </div>

--- a/src/assemblies/data/ncaab/matchup/TeamMatchups/TeamMatchups.tsx
+++ b/src/assemblies/data/ncaab/matchup/TeamMatchups/TeamMatchups.tsx
@@ -50,7 +50,7 @@ export const TeamMatchups : FC<TeamMatchupsProps>  = (props) =>{
         style={{...!props.overrideStyle ? TEAM_MATCHUPS_STYLE : {}, ...props.style}}>
             <h2 style={{
                 textAlign : 'left'
-            }} className='text-lg'>{_team.Name} Matchups</h2>
+            }} className='text-lg'>{_team.School} Matchups</h2>
             <hr/>
             <div className='grid gap-4'>
                 {matchupEntries}

--- a/src/assemblies/data/ncaab/team/PickTeamLarge/PickTeamLarge.tsx
+++ b/src/assemblies/data/ncaab/team/PickTeamLarge/PickTeamLarge.tsx
@@ -29,7 +29,7 @@ export const PickTeamLarge : FC<PickTeamLargeProps>  = (props) =>{
     const handleTextSearch = (text : string)=>{
         const searchTeams = _teams.filter((team)=>{
             return (text.length < 1) 
-            || text.toLowerCase().includes(team.Name.toLowerCase())
+            || text.toLowerCase().includes(team.School.toLowerCase())
             || text.toLowerCase().includes(team.School.toLowerCase());
         })
         setFilteredTeams(searchTeams);

--- a/src/assemblies/data/ncaab/team/SideTeam/SideTeam.tsx
+++ b/src/assemblies/data/ncaab/team/SideTeam/SideTeam.tsx
@@ -45,7 +45,7 @@ export const SideTeam : FC<SideTeamProps>  = (props) =>{
                 <img width={60} src={team.TeamLogoUrl}/>
             </div>
             <div>
-                <h2 className='text'>{team.Name}</h2>
+                <h2 className='text'>{team.School}</h2>
                 <h2 className='text-sm'>{props.away ? "Away" : "Home"}</h2>
             </div>
         </Button>

--- a/src/assemblies/data/ncaab/team/StackedTeam/StackedTeam.tsx
+++ b/src/assemblies/data/ncaab/team/StackedTeam/StackedTeam.tsx
@@ -42,7 +42,7 @@ export const StackedTeam : FC<StackedTeamProps>  = (props) =>{
         style={{...!props.overrideStyle ? STACKED_TEAM_STYLE : {}, ...props.style}}>
             <img width={60} src={_home.TeamLogoUrl}/>
             <br/>
-            {_home.Name}
+            {_home.School}
         </Button>
     )
 };

--- a/src/assemblies/data/ncaab/team/TeamGaguruStatBarChart/TeamGaguruStatsBarChart.tsx
+++ b/src/assemblies/data/ncaab/team/TeamGaguruStatBarChart/TeamGaguruStatsBarChart.tsx
@@ -105,7 +105,7 @@ export const TeamGaguruStatsBarChart : FC<TeamGaguruStatsBarChartProps>  = (prop
                         </div>
                         &emsp;
                         <div>
-                        {_team.Name}
+                        {_team.School}
                         </div>
                     </div>
                     <div style={{


### PR DESCRIPTION
We should be displaying names of schools, rather than the names of the school mascots, as mascot names aren't as commonly known.

Example: Display "UCLA" rather than "Bruins".

Code Changes:
* Use `Team.School` rather than `Team.Name`