### PR TITLE
Remove Bubble Headers on Home Page and Matchup Page

### DIFF
--- a/src/assemblies/data/ncaab/overview/NcaabMensAllUpcomingGames/NcaabMensAllUpcomingGames.tsx
+++ b/src/assemblies/data/ncaab/overview/NcaabMensAllUpcomingGames/NcaabMensAllUpcomingGames.tsx
@@ -79,7 +79,6 @@ export const NcaabMensAllUpcomingGames : FC<NcaabMensAllUpcomingGamesProps>  = (
         onMatchupClick={props.onMatchupClick}
         onTeamClick={props.onTeamClick}
         Title={<h2 className='text-2xl'>Today's Games</h2>}
-        presets={ALL_UPCOMING_GAMES_PRESETS}
         games={props.allUpcomingGames}/>
     )
 };

--- a/src/assemblies/data/ncaab/overview/NcaabMensUpcomingGames/NcaabMensUpcomingGames.tsx
+++ b/src/assemblies/data/ncaab/overview/NcaabMensUpcomingGames/NcaabMensUpcomingGames.tsx
@@ -39,7 +39,6 @@ export const NcaabMensUpcomingGames : FC<NcaabMensUpcomingGamesProps>  = (props)
         onMatchupClick={props.onMatchupClick}
         onTeamClick={props.onTeamClick}
         Title={<h2 className='text-xl'>Top 25 Games</h2>}
-        presets={ALL_UPCOMING_GAMES_PRESETS}
         games={props.top25Games}/>
     )
 };


### PR DESCRIPTION
Headers:
Remove these bubbles from the headers on the home page and the matchup page:
![image](https://github.com/gameday-guru/gdg-recomplib/assets/46224768/f6becf58-21f3-4ef0-98c0-33ec12e106d0)

Trello Ticket:
https://trello.com/c/1UgYWSEY/10-remove-bubble-headers-on-home-page-and-matchup-page
